### PR TITLE
chore: bump gravitee-parent version to 20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <!-- <version>15.1</version> -->
-        <version>15.1</version>
+        <version>20.0</version>
     </parent>
 
     <groupId>io.gravitee.reporter</groupId>


### PR DESCRIPTION
Closes gravitee-io/issues#5580