### PR TITLE
fix: properly disable jackson field filtering

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterProvider.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterProvider.java
@@ -30,17 +30,8 @@ public class FieldFilterProvider extends SimpleFilterProvider {
      * Creates a jackson filter provider that aims to serialize only fields corresponding to the field expression passed in parameter.
      */
     public FieldFilterProvider(Rules rules) {
-        if (shouldAddFilter(rules)) {
-            // Only add filter if required.
-            this.addFilter(JACKSON_JSON_FILTER_NAME, new FieldPropertyFilter(
-                    rules.getRenameFields(), rules.getIncludeFields(), rules.getExcludeFields()
-            ));
-        }
-    }
-
-    private boolean shouldAddFilter(Rules rules) {
-        return rules != null && ((rules.getRenameFields() != null && !rules.getRenameFields().isEmpty())
-                || (rules.getIncludeFields() != null && !rules.getIncludeFields().isEmpty())
-                || (rules.getExcludeFields() != null && !rules.getExcludeFields().isEmpty()));
+        this.addFilter(JACKSON_JSON_FILTER_NAME, new FieldPropertyFilter(
+            rules.getRenameFields(), rules.getIncludeFields(), rules.getExcludeFields()
+        ));
     }
 }


### PR DESCRIPTION
Jackson requires to define the filter if declared in a Mixin.
Filter is now always declared but does nothing if no field filtering is configured.

Closes gravitee-io/issues#6911