### PR TITLE
Fix metric wording for message

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -59,7 +59,7 @@ public final class MessageMetrics extends AbstractReportable {
     private long count = -1;
 
     @Builder.Default
-    private long errorsCount = -1;
+    private long errorCount = -1;
 
     @Builder.Default
     private long gatewayLatencyMs = -1;


### PR DESCRIPTION
Fix metric wording for message
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-fix-metrics-name-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.25.0-fix-metrics-name-SNAPSHOT/gravitee-reporter-api-1.25.0-fix-metrics-name-SNAPSHOT.zip)
  <!-- Version placeholder end -->
