### PR TITLE
fix: rename path to pathInfo on v4 metrics

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -16,7 +16,6 @@
 package io.gravitee.reporter.api.v4.metric;
 
 import io.gravitee.common.http.HttpMethod;
-import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.reporter.api.AbstractReportable;
 import io.gravitee.reporter.api.http.SecurityType;
 import io.gravitee.reporter.api.v4.log.Log;
@@ -68,7 +67,7 @@ public class Metrics extends AbstractReportable {
     private String remoteAddress;
     private String host;
     private String uri;
-    private String path;
+    private String pathInfo;
     private String mappedPath;
     private String userAgent;
 
@@ -160,7 +159,7 @@ public class Metrics extends AbstractReportable {
             logV2.setProxyResponse(log.getEndpointResponse());
             metricsV2.setLog(logV2);
         }
-        metricsV2.setPath(path);
+        metricsV2.setPath(pathInfo);
         metricsV2.setMappedPath(mappedPath);
         metricsV2.setUserAgent(userAgent);
         metricsV2.setUser(user);

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/NoopMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/NoopMetrics.java
@@ -77,7 +77,7 @@ public class NoopMetrics extends Metrics {
     public void setUri(final String uri) {}
 
     @Override
-    public void setPath(final String path) {}
+    public void setPathInfo(final String pathInfo) {}
 
     @Override
     public void setMappedPath(final String mappedPath) {}


### PR DESCRIPTION
**Issue**

[APIM-490](https://gravitee.atlassian.net/browse/APIM-490)

**Description**

Rename path to path info in metrics V4 in order to be aligned with the actual content of this metric.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

[APIM-490]: https://gravitee.atlassian.net/browse/APIM-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-rename-path-to-path-info-in-v4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.25.0-rename-path-to-path-info-in-v4-SNAPSHOT/gravitee-reporter-api-1.25.0-rename-path-to-path-info-in-v4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
