### PR TITLE
feat: add error status on message metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,14 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-api</artifactId>
-    <version>1.25.0-alpha.3</version>
+    <version>1.25.0-apim-490-add-error-metric-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Reporter - API</name>
 
     <properties>
         <gravitee-bom.version>2.6</gravitee-bom.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-gateway-api.version>2.0.0-alpha.5</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.10</gravitee-gateway-api.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 

--- a/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
@@ -18,9 +18,7 @@ package io.gravitee.reporter.api.v4.common;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import java.util.Map;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -62,6 +62,9 @@ public final class MessageMetrics extends AbstractReportable {
     private long errorCount = -1;
 
     @Builder.Default
+    private boolean error = false;
+
+    @Builder.Default
     private long gatewayLatencyMs = -1;
 
     /**


### PR DESCRIPTION
**Description**

Adding error status on message metrics.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-apim-490-add-error-metric-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.25.0-apim-490-add-error-metric-SNAPSHOT/gravitee-reporter-api-1.25.0-apim-490-add-error-metric-SNAPSHOT.zip)
  <!-- Version placeholder end -->
