### PR TITLE
fix(deps): upgrade gravitee-bom & gravitee-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.reporter</groupId>
@@ -34,9 +34,9 @@
     <name>Gravitee.io APIM - Reporter - API</name>
 
     <properties>
-        <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.10</gravitee-gateway-api.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 
@@ -59,12 +59,14 @@
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
             <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
             <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Upgrade gravitee-bom & gravitee-common

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-upgrade-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.25.0-upgrade-deps-SNAPSHOT/gravitee-reporter-api-1.25.0-upgrade-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
