### PR TITLE
feat: add jackson deserialization capabilities

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
+++ b/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
@@ -21,11 +21,15 @@ import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@SuperBuilder
+@Jacksonized
 public class EndpointStatus extends AbstractReportable {
 
     /**

--- a/src/main/java/io/gravitee/reporter/api/health/Step.java
+++ b/src/main/java/io/gravitee/reporter/api/health/Step.java
@@ -17,11 +17,15 @@ package io.gravitee.reporter.api.health;
 
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@SuperBuilder
+@Jacksonized
 public class Step {
 
     /**

--- a/src/main/java/io/gravitee/reporter/api/http/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/http/Metrics.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -31,6 +33,8 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@Jacksonized
+@SuperBuilder
 public class Metrics extends AbstractReportable {
 
     private long proxyResponseTimeMs = 0;

--- a/src/main/java/io/gravitee/reporter/api/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/log/Log.java
@@ -18,11 +18,16 @@ package io.gravitee.reporter.api.log;
 import io.gravitee.reporter.api.AbstractReportable;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
+import lombok.Builder;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Jacksonized
+@SuperBuilder
 public class Log extends AbstractReportable {
 
     private String api;

--- a/src/main/java/io/gravitee/reporter/api/monitor/JvmInfo.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/JvmInfo.java
@@ -15,10 +15,16 @@
  */
 package io.gravitee.reporter.api.monitor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@NoArgsConstructor
 public final class JvmInfo {
 
     public long timestamp = -1;
@@ -50,6 +56,7 @@ public final class JvmInfo {
         }
     }
 
+    @NoArgsConstructor
     public static class MemoryPool {
 
         public String name;

--- a/src/main/java/io/gravitee/reporter/api/monitor/Monitor.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/Monitor.java
@@ -16,11 +16,15 @@
 package io.gravitee.reporter.api.monitor;
 
 import io.gravitee.reporter.api.AbstractReportable;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Jacksonized
+@SuperBuilder
 public class Monitor extends AbstractReportable {
 
     JvmInfo jvm;

--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -18,11 +18,9 @@ package io.gravitee.reporter.api.v4.log;
 import io.gravitee.reporter.api.AbstractReportable;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -31,6 +29,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @SuperBuilder
+@Jacksonized
 public class Log extends AbstractReportable {
 
     private String apiId;

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -31,6 +32,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @SuperBuilder
+@Jacksonized
 @ToString(callSuper = true)
 public class MessageLog extends AbstractReportable {
 

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -32,6 +33,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @SuperBuilder
+@Jacksonized
 @ToString(callSuper = true)
 public final class MessageMetrics extends AbstractReportable {
 


### PR DESCRIPTION
This is mainly to be able to add some tests to [gravitee-reporter-common](https://github.com/gravitee-io/gravitee-reporter-common) based on file samples.

see https://gravitee.atlassian.net/browse/APIM-2502
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.26.0-feat-jackson-deser-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.26.0-feat-jackson-deser-SNAPSHOT/gravitee-reporter-api-1.26.0-feat-jackson-deser-SNAPSHOT.zip)
  <!-- Version placeholder end -->
