### PR TITLE
feat: define toBuilder attribute on metrics builder

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
+++ b/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
@@ -32,7 +32,7 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public abstract class AbstractReportable implements Reportable {
 
     private long timestamp;

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -37,7 +37,7 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class Metrics extends AbstractReportable {
 
     @Builder.Default


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

This is useful to quickly create a clone of a metrics using `metrics.toBuilder().build()`


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.0-update-metrics-builder-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.27.0-update-metrics-builder-SNAPSHOT/gravitee-reporter-api-1.27.0-update-metrics-builder-SNAPSHOT.zip)
  <!-- Version placeholder end -->
