### PR TITLE
feat: add doOnReport feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-api</artifactId>
-    <version>1.27.0</version>
+    <version>1.28.0-apim-2626-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Reporter - API</name>
 

--- a/src/main/java/io/gravitee/reporter/api/common/ReportAction.java
+++ b/src/main/java/io/gravitee/reporter/api/common/ReportAction.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api.common;
+
+import java.util.function.Consumer;
+
+public interface ReportAction<T> extends Consumer<T> {}

--- a/src/main/java/io/gravitee/reporter/api/common/Request.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Request.java
@@ -17,6 +17,8 @@ package io.gravitee.reporter.api.common;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -28,6 +30,8 @@ import lombok.Setter;
 @Setter
 public class Request {
 
+    private List<ReportAction<Request>> onReportActions;
+
     private HttpMethod method;
 
     private HttpHeaders headers;
@@ -35,4 +39,14 @@ public class Request {
     private String uri;
 
     private String body;
+
+    public Request doOnReport(ReportAction<Request> action) {
+        if (onReportActions == null) {
+            onReportActions = new ArrayList<>();
+        }
+
+        onReportActions.add(action);
+
+        return this;
+    }
 }

--- a/src/main/java/io/gravitee/reporter/api/common/Response.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Response.java
@@ -16,6 +16,8 @@
 package io.gravitee.reporter.api.common;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,6 +31,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Response {
 
+    private List<ReportAction<Response>> onReportActions;
+
     private int status;
 
     private HttpHeaders headers;
@@ -37,5 +41,15 @@ public class Response {
 
     public Response(final int status) {
         this.status = status;
+    }
+
+    public Response doOnReport(ReportAction<Response> action) {
+        if (onReportActions == null) {
+            onReportActions = new ArrayList<>();
+        }
+
+        onReportActions.add(action);
+
+        return this;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2626

**Description**

Allow to define actions that will be executed in the report processor of the gateway
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.28.0-apim-2626-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.28.0-apim-2626-SNAPSHOT/gravitee-reporter-api-1.28.0-apim-2626-SNAPSHOT.zip)
  <!-- Version placeholder end -->
