### PR TITLE
feat: add doOnReport feature on messages

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
@@ -16,6 +16,10 @@
 package io.gravitee.reporter.api.v4.common;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.reporter.api.common.ReportAction;
+import io.gravitee.reporter.api.common.Request;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,9 +32,20 @@ import lombok.Setter;
 @Setter
 public class Message {
 
+    private List<ReportAction<Message>> onReportActions;
     private String id;
     private HttpHeaders headers;
     private String payload;
     private Map<String, Object> metadata;
     private boolean error;
+
+    public Message doOnReport(ReportAction<Message> action) {
+        if (onReportActions == null) {
+            onReportActions = new ArrayList<>();
+        }
+
+        onReportActions.add(action);
+
+        return this;
+    }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2626

**Description**

Allow to define actions that will be executed in the report processor of the reactor message engine of the gateway
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.29.0-apim-2626-make-dataloggingmasking-work-in-V4-engine-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.29.0-apim-2626-make-dataloggingmasking-work-in-V4-engine-SNAPSHOT/gravitee-reporter-api-1.29.0-apim-2626-make-dataloggingmasking-work-in-V4-engine-SNAPSHOT.zip)
  <!-- Version placeholder end -->
