### PR TITLE
fix: add HttpHeaders Deserializer

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializer.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api.jackson;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpHeadersDeserializer extends StdDeserializer<HttpHeaders> {
+
+    public HttpHeadersDeserializer() {
+        super(HttpHeaders.class);
+    }
+
+    @Override
+    public HttpHeaders deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        JsonNode jn = jp.getCodec().readTree(jp);
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        jp.getCodec().treeToValue(jn, Map.class).forEach((k, v) -> httpHeaders.add((CharSequence) k, (List<CharSequence>) v));
+        return httpHeaders;
+    }
+}

--- a/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api.jackson;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.reporter.api.configuration.Rules;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpHeadersDeserializerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void initializeObjectMapper() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(HttpHeaders.class, new HttpHeadersDeserializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void shouldSerializeHttpHeaders() throws JsonProcessingException {
+        Map<String, List<String>> header = new HashMap<>();
+        header.put("header1", List.of("value1"));
+        header.put("header2", List.of("value2"));
+        header.put("header3", List.of("value3"));
+
+        HttpHeaders httpHeaders = objectMapper.readValue(objectMapper.writeValueAsString(header), HttpHeaders.class);
+
+        assertEquals("value1", httpHeaders.getAll("header1").get(0));
+        assertEquals("value2", httpHeaders.getAll("header2").get(0));
+        assertEquals("value3", httpHeaders.getAll("header3").get(0));
+    }
+}


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-3825
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.28.1-deserializer-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.28.1-deserializer-SNAPSHOT/gravitee-reporter-api-1.28.1-deserializer-SNAPSHOT.zip)
  <!-- Version placeholder end -->
