### PR TITLE
feat: add entrypoint id to v4 metrics index

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -76,6 +76,10 @@ public class Metrics extends AbstractReportable {
 
     private boolean requestEnded;
     /**
+     * Entrypoint metrics
+     */
+    private String entrypointId;
+    /**
      * Endpoint metrics
      */
     private String endpoint;


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-3481

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.29.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.29.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT/gravitee-reporter-api-1.29.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
