### PR TITLE
feat: add count increments for MessageMetrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/archi
+*       @gravitee-io/apim

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -64,6 +64,12 @@ public final class MessageMetrics extends AbstractReportable {
     private long errorCount = -1;
 
     @Builder.Default
+    private long countIncrement = -1;
+
+    @Builder.Default
+    private long errorCountIncrement = -1;
+
+    @Builder.Default
     private boolean error = false;
 
     @Builder.Default


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4801

**Description**

Adds countIncrement and errorCountIncrement that will hold the number of messages and errors between two reporting
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.30.0-apim-4801-messages-count-increment-metric-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.30.0-apim-4801-messages-count-increment-metric-SNAPSHOT/gravitee-reporter-api-1.30.0-apim-4801-messages-count-increment-metric-SNAPSHOT.zip)
  <!-- Version placeholder end -->
