### PR TITLE
feat: Show API name in reporters

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
+++ b/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
@@ -43,6 +43,11 @@ public class EndpointStatus extends AbstractReportable {
     private final String api;
 
     /**
+     * Api Name
+     */
+    private final String apiName;
+
+    /**
      * Endpoint name.
      */
     private final String endpoint;
@@ -77,13 +82,14 @@ public class EndpointStatus extends AbstractReportable {
      */
     private boolean transition = false;
 
-    private EndpointStatus(long timestamp, String api, String endpoint, List<Step> steps) {
+    private EndpointStatus(long timestamp, String api, String endpoint, List<Step> steps, String apiName) {
         super(timestamp);
         this.id = UUID.toString(UUID.random());
         this.api = api;
         this.endpoint = endpoint;
         this.steps = steps;
         this.success = steps.stream().allMatch(Step::isSuccess);
+        this.apiName = apiName;
     }
 
     public String getId() {
@@ -138,6 +144,10 @@ public class EndpointStatus extends AbstractReportable {
         this.transition = transition;
     }
 
+    public String getApiName() {
+        return apiName;
+    }
+
     public static Builder forEndpoint(String api, String endpoint) {
         return new Builder(api, endpoint);
     }
@@ -155,6 +165,8 @@ public class EndpointStatus extends AbstractReportable {
 
         private List<Step> steps = new ArrayList<>();
 
+        private String apiName;
+
         private Builder(String api, String endpoint) {
             this.api = api;
             this.endpoint = endpoint;
@@ -170,8 +182,13 @@ public class EndpointStatus extends AbstractReportable {
             return this;
         }
 
+        public Builder apiName(String apiName) {
+            this.apiName = apiName;
+            return this;
+        }
+
         public EndpointStatus build() {
-            return new EndpointStatus(timestamp, api, endpoint, steps);
+            return new EndpointStatus(timestamp, api, endpoint, steps, apiName);
         }
     }
 

--- a/src/main/java/io/gravitee/reporter/api/http/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/http/Metrics.java
@@ -42,6 +42,7 @@ public class Metrics extends AbstractReportable {
     private long apiResponseTimeMs = 0;
     private String requestId;
     private String api;
+    private String apiName;
     private String application;
     private String transactionId;
     private String clientIdentifier;

--- a/src/main/java/io/gravitee/reporter/api/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/log/Log.java
@@ -32,6 +32,8 @@ public class Log extends AbstractReportable {
 
     private String api;
 
+    private String apiName;
+
     /**
      * Log identifier is equivalent to the request identifier
      */
@@ -91,5 +93,13 @@ public class Log extends AbstractReportable {
 
     public void setProxyResponse(Response proxyResponse) {
         this.proxyResponse = proxyResponse;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
     }
 }

--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -33,6 +33,7 @@ import lombok.extern.jackson.Jacksonized;
 public class Log extends AbstractReportable {
 
     private String apiId;
+    private String apiName;
 
     /**
      * Log identifier is equivalent to the request identifier

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -37,6 +37,7 @@ import lombok.extern.jackson.Jacksonized;
 public class MessageLog extends AbstractReportable {
 
     private String apiId;
+    private String apiName;
     private String requestId;
     private String clientIdentifier;
     private String correlationId;

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -42,6 +42,7 @@ public final class MessageMetrics extends AbstractReportable {
      */
     private String requestId;
     private String apiId;
+    private String apiName;
     private String clientIdentifier;
     private String correlationId;
     private String parentCorrelationId;

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -49,6 +49,7 @@ public class Metrics extends AbstractReportable {
     private String requestId;
     private String transactionId;
     private String apiId;
+    private String apiName;
     private String apiType;
     private String planId;
     private String applicationId;
@@ -138,6 +139,7 @@ public class Metrics extends AbstractReportable {
         metricsV2.setApiResponseTimeMs(endpointResponseTimeMs);
         metricsV2.setRequestId(requestId);
         metricsV2.setApi(apiId);
+        metricsV2.setApiName(apiName);
         metricsV2.setApplication(applicationId);
         metricsV2.setTransactionId(transactionId);
         metricsV2.setClientIdentifier(clientIdentifier);
@@ -157,6 +159,7 @@ public class Metrics extends AbstractReportable {
             io.gravitee.reporter.api.log.Log logV2 = new io.gravitee.reporter.api.log.Log(log.getTimestamp());
             logV2.setRequestId(log.getRequestId());
             logV2.setApi(log.getApiId());
+            logV2.setApiName(log.getApiName());
             logV2.setClientRequest(log.getEntrypointRequest());
             logV2.setClientResponse(log.getEntrypointResponse());
             logV2.setProxyRequest(log.getEndpointRequest());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-3932

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.31.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.31.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT/gravitee-reporter-api-1.31.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT.zip)
  <!-- Version placeholder end -->
