### PR TITLE
fix: Include api name in health check report

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
+++ b/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
@@ -148,8 +148,8 @@ public class EndpointStatus extends AbstractReportable {
         return apiName;
     }
 
-    public static Builder forEndpoint(String api, String endpoint) {
-        return new Builder(api, endpoint);
+    public static Builder forEndpoint(String api, String apiName, String endpoint) {
+        return new Builder(api, apiName, endpoint);
     }
 
     public static StepBuilder forStep(String step) {
@@ -167,9 +167,10 @@ public class EndpointStatus extends AbstractReportable {
 
         private String apiName;
 
-        private Builder(String api, String endpoint) {
+        private Builder(String api, String apiName, String endpoint) {
             this.api = api;
             this.endpoint = endpoint;
+            this.apiName = apiName;
         }
 
         public Builder on(long timestamp) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-3932

**Description**

Added api name in health check report

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.31.1-apim-3932-api-name-in-health-check-report-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.31.1-apim-3932-api-name-in-health-check-report-SNAPSHOT/gravitee-reporter-api-1.31.1-apim-3932-api-name-in-health-check-report-SNAPSHOT.zip)
  <!-- Version placeholder end -->
