### PR TITLE
fix: Add backward compatibility for EndpointStatus.forEndpoint

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
+++ b/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
@@ -148,6 +148,10 @@ public class EndpointStatus extends AbstractReportable {
         return apiName;
     }
 
+    public static Builder forEndpoint(String api, String endpoint) {
+        return forEndpoint(api, null, endpoint);
+    }
+
     public static Builder forEndpoint(String api, String apiName, String endpoint) {
         return new Builder(api, apiName, endpoint);
     }


### PR DESCRIPTION
**Description**

Added backward compatibility for installations without api name reporting.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.31.2-fix-add-backward-compatibility-for-endpoint-status-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.31.2-fix-add-backward-compatibility-for-endpoint-status-SNAPSHOT/gravitee-reporter-api-1.31.2-fix-add-backward-compatibility-for-endpoint-status-SNAPSHOT.zip)
  <!-- Version placeholder end -->
