### PR TITLE
fix: update default response and latency time values from -1 to 0

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -73,7 +73,7 @@ public class Metrics extends AbstractReportable {
     private String userAgent;
 
     @Builder.Default
-    private long requestContentLength = -1;
+    private long requestContentLength = 0;
 
     private boolean requestEnded;
     /**
@@ -86,7 +86,7 @@ public class Metrics extends AbstractReportable {
     private String endpoint;
 
     @Builder.Default
-    private long endpointResponseTimeMs = -1;
+    private long endpointResponseTimeMs = 0;
 
     /**
      * Response metrics
@@ -94,13 +94,13 @@ public class Metrics extends AbstractReportable {
     private int status;
 
     @Builder.Default
-    private long responseContentLength = -1;
+    private long responseContentLength = 0;
 
     @Builder.Default
-    private long gatewayResponseTimeMs = -1;
+    private long gatewayResponseTimeMs = 0;
 
     @Builder.Default
-    private long gatewayLatencyMs = -1;
+    private long gatewayLatencyMs = 0;
 
     /**
      * Security metrics


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-8469

**Description**

fix: update default values for v4 APIs similar to v2 apis

Current default values for v2:
<img width="598" alt="Screenshot 2025-04-15 at 5 44 20 PM" src="https://github.com/user-attachments/assets/305e2c46-1087-4a6c-a604-c460a4e9ad4b" />

Updated structure for v4 apis:
<img width="640" alt="Screenshot 2025-04-15 at 5 45 35 PM" src="https://github.com/user-attachments/assets/24cd82cc-e7f3-4143-ad2a-a786d845e748" />


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.31.3-APIM-8469-fix-negative-default-values-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.31.3-APIM-8469-fix-negative-default-values-SNAPSHOT/gravitee-reporter-api-1.31.3-APIM-8469-fix-negative-default-values-SNAPSHOT.zip)
  <!-- Version placeholder end -->
