### PR TITLE
Handle new AI metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>gravitee-io/renovate-config:lib"]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.3.0</version>
     </parent>
 
     <groupId>io.gravitee.reporter</groupId>
@@ -34,10 +34,9 @@
     <name>Gravitee.io APIM - Reporter - API</name>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
-        <gravitee-common.version>2.3.0</gravitee-common.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
-        <lombok.version>1.18.38</lombok.version>
+        <gravitee-bom.version>8.2.22</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.11.1</gravitee-gateway-api.version>
+        <gravitee-common.version>4.6.1</gravitee-common.version>
     </properties>
 
     <dependencyManagement>
@@ -83,7 +82,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -99,25 +97,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.18</version>
-                <configuration>
-                    <prettierJavaVersion>1.6.2</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,13 @@
 
         <!-- Unit Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
+++ b/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/Reportable.java
+++ b/src/main/java/io/gravitee/reporter/api/Reportable.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/Reporter.java
+++ b/src/main/java/io/gravitee/reporter/api/Reporter.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/common/ReportAction.java
+++ b/src/main/java/io/gravitee/reporter/api/common/ReportAction.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/common/Request.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Request.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/common/Response.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Response.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/configuration/Rules.java
+++ b/src/main/java/io/gravitee/reporter/api/configuration/Rules.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
+++ b/src/main/java/io/gravitee/reporter/api/health/EndpointStatus.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/health/Step.java
+++ b/src/main/java/io/gravitee/reporter/api/health/Step.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/http/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/http/Metrics.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/http/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/http/Metrics.java
@@ -21,7 +21,6 @@ import io.gravitee.reporter.api.log.Log;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;

--- a/src/main/java/io/gravitee/reporter/api/http/SecurityType.java
+++ b/src/main/java/io/gravitee/reporter/api/http/SecurityType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterMixin.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterMixin.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterProvider.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/FieldFilterProvider.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/FieldPropertyFilter.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/FieldPropertyFilter.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializer.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializer.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializer.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializer.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/jackson/JacksonUtils.java
+++ b/src/main/java/io/gravitee/reporter/api/jackson/JacksonUtils.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/log/Log.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/monitor/JvmInfo.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/JvmInfo.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/monitor/Monitor.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/Monitor.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/monitor/OsInfo.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/OsInfo.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/monitor/ProcessInfo.java
+++ b/src/main/java/io/gravitee/reporter/api/monitor/ProcessInfo.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/common/Message.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/common/MessageConnectorType.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/common/MessageConnectorType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/common/MessageOperation.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/common/MessageOperation.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/AIMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/AIMetrics.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api.v4.metric;
+
+record AIMetrics(long inputTokens, long outputTokens) {}

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/MessageMetrics.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -21,6 +21,8 @@ import io.gravitee.reporter.api.http.SecurityType;
 import io.gravitee.reporter.api.v4.log.Log;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalLong;
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -102,6 +104,9 @@ public class Metrics extends AbstractReportable {
     @Builder.Default
     private long gatewayLatencyMs = -1;
 
+    @Nullable
+    private AIMetrics aiMetrics;
+
     /**
      * Security metrics
      */
@@ -177,5 +182,18 @@ public class Metrics extends AbstractReportable {
         metricsV2.setZone(zone);
         metricsV2.setCustomMetrics(customMetrics);
         return metricsV2;
+    }
+
+    public Metrics aiTokens(long input, long output) {
+        aiMetrics = new AIMetrics(input, output);
+        return this;
+    }
+
+    public OptionalLong aiInputTokens() {
+        return aiMetrics == null ? OptionalLong.empty() : OptionalLong.of(aiMetrics.inputTokens());
+    }
+
+    public OptionalLong aiOutputTokens() {
+        return aiMetrics == null ? OptionalLong.empty() : OptionalLong.of(aiMetrics.outputTokens());
     }
 }

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/NoopMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/NoopMetrics.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersDeserializerTest.java
@@ -15,46 +15,40 @@
  */
 package io.gravitee.reporter.api.jackson;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.reporter.api.configuration.Rules;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class HttpHeadersDeserializerTest {
+class HttpHeadersDeserializerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
-    public void initializeObjectMapper() {
+    @BeforeEach
+    void initializeObjectMapper() {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(HttpHeaders.class, new HttpHeadersDeserializer());
         objectMapper.registerModule(module);
     }
 
     @Test
-    public void shouldSerializeHttpHeaders() throws JsonProcessingException {
-        Map<String, List<String>> header = new HashMap<>();
-        header.put("header1", List.of("value1"));
-        header.put("header2", List.of("value2"));
-        header.put("header3", List.of("value3"));
+    void shouldSerializeHttpHeaders() throws JsonProcessingException {
+        Map<String, List<String>> header = Map.of("header1", List.of("value1"), "header2", List.of("value2"), "header3", List.of("value3"));
 
         HttpHeaders httpHeaders = objectMapper.readValue(objectMapper.writeValueAsString(header), HttpHeaders.class);
 
-        assertEquals("value1", httpHeaders.getAll("header1").get(0));
-        assertEquals("value2", httpHeaders.getAll("header2").get(0));
-        assertEquals("value3", httpHeaders.getAll("header3").get(0));
+        assertThat(httpHeaders.getAll("header1")).first().isEqualTo("value1");
+        assertThat(httpHeaders.getAll("header2")).first().isEqualTo("value2");
+        assertThat(httpHeaders.getAll("header3")).first().isEqualTo("value3");
     }
 }

--- a/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializerTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializerTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializerTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/HttpHeadersSerializerTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.reporter.api.jackson;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -23,22 +23,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.configuration.Rules;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class HttpHeadersSerializerTest {
+class HttpHeadersSerializerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
-    public void initializeObjectMapper() {
+    @BeforeEach
+    void initializeObjectMapper() {
         SimpleModule module = new SimpleModule();
         module.addSerializer(HttpHeaders.class, new HttpHeadersSerializer(new Rules()));
         objectMapper.registerModule(module);
     }
 
     @Test
-    public void shouldSerializeHttpHeaders() throws JsonProcessingException {
+    void shouldSerializeHttpHeaders() throws JsonProcessingException {
         HttpHeaders httpHeaders = HttpHeaders.create();
         httpHeaders.add("header1", "value1");
         httpHeaders.add("header2", "value2");
@@ -48,8 +48,8 @@ public class HttpHeadersSerializerTest {
 
         JsonNode node = new ObjectMapper().readTree(output);
 
-        assertEquals("value1", node.get("header1").get(0).asText());
-        assertEquals("value3", node.get("header1").get(1).asText());
-        assertEquals("value2", node.get("header2").get(0).asText());
+        assertThat(node.get("header1").get(0).asText()).isEqualTo("value1");
+        assertThat(node.get("header1").get(1).asText()).isEqualTo("value3");
+        assertThat(node.get("header2").get(0).asText()).isEqualTo("value2");
     }
 }

--- a/src/test/java/io/gravitee/reporter/api/jackson/JsonFormatterTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/JsonFormatterTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/reporter/api/jackson/JsonFormatterTest.java
+++ b/src/test/java/io/gravitee/reporter/api/jackson/JsonFormatterTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.reporter.api.jackson;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,20 +36,16 @@ import io.gravitee.reporter.api.http.Metrics;
 import io.gravitee.reporter.api.log.Log;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
-public class JsonFormatterTest {
+class JsonFormatterTest {
 
     @Test
-    public void shouldRenameField() throws JsonProcessingException {
+    void shouldRenameField() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setRenameFields(Map.of("application", "app"));
 
@@ -62,12 +60,12 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertFalse(node.has("application"));
-        Assert.assertTrue(node.has("app"));
+        assertThat(node.has("application")).isFalse();
+        assertThat(node.has("app")).isTrue();
     }
 
     @Test
-    public void shouldFilterField() throws JsonProcessingException {
+    void shouldFilterField() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("application"));
 
@@ -82,11 +80,11 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertFalse(node.has("application"));
+        assertThat(node.has("application")).isFalse();
     }
 
     @Test
-    public void shouldExcludeAllFields() throws JsonProcessingException {
+    void shouldExcludeAllFields() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("*"));
 
@@ -101,11 +99,11 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals(0, node.size());
+        assertThat(node).isEmpty();
     }
 
     @Test
-    public void shouldExcludeAndIncludeSameField() throws JsonProcessingException {
+    void shouldExcludeAndIncludeSameField() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("api"));
         rules.setIncludeFields(Set.of("api"));
@@ -121,11 +119,11 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertTrue(node.has("api"));
+        assertThat(node.has("api")).isTrue();
     }
 
     @Test
-    public void shouldExcludeAllFields_butIncludeOneField() throws JsonProcessingException {
+    void shouldExcludeAllFields_butIncludeOneField() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("*"));
         rules.setIncludeFields(Set.of("api"));
@@ -141,12 +139,12 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals(1, node.size());
-        Assert.assertTrue(node.has("api"));
+        assertThat(node.has("api")).isTrue();
+        assertThat(node).hasSize(1);
     }
 
     @Test
-    public void shouldExcludeAllFields_butIncludeAHeaderField() throws JsonProcessingException {
+    void shouldExcludeAllFields_butIncludeAHeaderField() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("*"));
         rules.setIncludeFields(
@@ -188,19 +186,19 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals("GET", node.get("log").get("clientRequest").get("method").asText());
-        Assert.assertEquals("localhost", node.get("log").get("clientRequest").get("headers").get("host").get(0).asText());
-        Assert.assertEquals("no-cache", node.get("log").get("clientRequest").get("headers").get("Cache-Control").get(0).asText());
-        Assert.assertFalse(node.get("log").get("clientRequest").get("headers").has("content-type"));
+        assertThat(node.get("log").get("clientRequest").get("method").asText()).isEqualTo("GET");
+        assertThat(node.get("log").get("clientRequest").get("headers").get("host").get(0).asText()).isEqualTo("localhost");
+        assertThat(node.get("log").get("clientRequest").get("headers").get("Cache-Control").get(0).asText()).isEqualTo("no-cache");
+        assertThat(node.get("log").get("clientRequest").get("headers").has("content-type")).isFalse();
 
-        Assert.assertFalse(node.get("log").has("proxyRequest"));
+        assertThat(node.get("log").has("proxyRequest")).isFalse();
 
-        Assert.assertEquals("200", node.get("log").get("clientResponse").get("status").asText());
-        Assert.assertEquals("10", node.get("log").get("clientResponse").get("headers").get("length").get(0).asText());
+        assertThat(node.get("log").get("clientResponse").get("status").asText()).isEqualTo("200");
+        assertThat(node.get("log").get("clientResponse").get("headers").get("length").get(0).asText()).isEqualTo("10");
     }
 
     @Test
-    public void shouldExcludeAllFields_butIncludeHeaders() throws JsonProcessingException {
+    void shouldExcludeAllFields_butIncludeHeaders() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("*"));
         rules.setIncludeFields(Set.of("log.clientRequest.headers"));
@@ -222,12 +220,12 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals("localhost", node.get("log").get("clientRequest").get("headers").get("host").get(0).asText());
-        Assert.assertEquals("application/json", node.get("log").get("clientRequest").get("headers").get("content-type").get(0).asText());
+        assertThat(node.get("log").get("clientRequest").get("headers").get("host").get(0).asText()).isEqualTo("localhost");
+        assertThat(node.get("log").get("clientRequest").get("headers").get("content-type").get(0).asText()).isEqualTo("application/json");
     }
 
     @Test
-    public void shouldExcludeASingleHeader() throws JsonProcessingException {
+    void shouldExcludeASingleHeader() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("log.clientRequest.headers.host"));
 
@@ -253,14 +251,14 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(metrics);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertFalse("localhost", node.get("log").get("clientRequest").get("headers").has("host"));
-        Assert.assertEquals("application/json", node.get("log").get("clientRequest").get("headers").get("content-type").get(0).asText());
 
-        Assert.assertEquals("localhost-2", node.get("log").get("proxyRequest").get("headers").get("host").get(0).asText());
+        assertThat(node.get("log").get("clientRequest").get("headers").has("host")).isFalse();
+        assertThat(node.get("log").get("clientRequest").get("headers").get("content-type").get(0).asText()).isEqualTo("application/json");
+        assertThat(node.get("log").get("proxyRequest").get("headers").get("host").get(0).asText()).isEqualTo("localhost-2");
     }
 
     @Test
-    public void shouldExcludeNestedFields() throws JsonProcessingException {
+    void shouldExcludeNestedFields() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("clientRequest"));
 
@@ -283,12 +281,12 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(log);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals(4, node.size());
-        Assert.assertFalse(node.has("clientRequest"));
+        assertThat(node).hasSize(4);
+        assertThat(node.has("clientRequest")).isFalse();
     }
 
     @Test
-    public void shouldExcludeNestedProperty() throws JsonProcessingException {
+    void shouldExcludeNestedProperty() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setExcludeFields(Set.of("clientRequest.uri"));
 
@@ -311,13 +309,13 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(log);
 
         JsonNode node = new ObjectMapper().readTree(output);
-        Assert.assertEquals(5, node.size());
-        Assert.assertTrue(node.has("clientRequest"));
-        Assert.assertEquals(0, node.get("clientRequest").size());
+        assertThat(node).hasSize(5);
+        assertThat(node.has("clientRequest")).isTrue();
+        assertThat(node.get("clientRequest")).isEmpty();
     }
 
     @Test
-    public void shouldRenameNestedProperty() throws JsonProcessingException {
+    void shouldRenameNestedProperty() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setRenameFields(Map.of("clientRequest.uri", "path"));
 
@@ -340,12 +338,11 @@ public class JsonFormatterTest {
         String output = mapper.writeValueAsString(log);
 
         JsonNode node = new ObjectMapper().readTree(output);
-
-        Assert.assertEquals(5, node.size());
-        Assert.assertTrue(node.has("clientRequest"));
-        Assert.assertEquals(1, node.get("clientRequest").size());
-        Assert.assertFalse(node.get("clientRequest").has("uri"));
-        Assert.assertTrue(node.get("clientRequest").has("path"));
+        assertThat(node).hasSize(5);
+        assertThat(node.has("clientRequest")).isTrue();
+        assertThat(node.get("clientRequest")).hasSize(1);
+        assertThat(node.get("clientRequest").has("uri")).isFalse();
+        assertThat(node.get("clientRequest").has("path")).isTrue();
     }
 
     private ObjectMapper initObjectMapper(Rules rules) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9340

**Description**

Add to new metrics to count number of token in/out for AI APIs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.32.0-apim-9340-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.32.0-apim-9340-SNAPSHOT/gravitee-reporter-api-1.32.0-apim-9340-SNAPSHOT.zip)
  <!-- Version placeholder end -->
