### PR TITLE
fix: remove instanceof check when getting an additional metric

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -200,7 +200,7 @@ public class Metrics extends AbstractReportable {
 
     @Nullable
     public Map<String, Long> longAdditionalMetrics() {
-        return additionalMetrics((key, value) -> key.startsWith("long_") && value instanceof Long);
+        return additionalMetrics((key, value) -> key.startsWith("long_"));
     }
 
     /**
@@ -218,7 +218,7 @@ public class Metrics extends AbstractReportable {
 
     @Nullable
     public Map<String, Double> doubleAdditionalMetrics() {
-        return additionalMetrics((key, value) -> key.startsWith("double_") && value instanceof Double);
+        return additionalMetrics((key, value) -> key.startsWith("double_"));
     }
 
     /**
@@ -236,7 +236,7 @@ public class Metrics extends AbstractReportable {
 
     @Nullable
     public Map<String, String> keywordAdditionalMetrics() {
-        return additionalMetrics((key, value) -> key.startsWith("keyword_") && value instanceof String);
+        return additionalMetrics((key, value) -> key.startsWith("keyword_"));
     }
 
     /**
@@ -254,7 +254,7 @@ public class Metrics extends AbstractReportable {
 
     @Nullable
     public Map<String, Boolean> boolAdditionalMetrics() {
-        return additionalMetrics((key, value) -> key.startsWith("bool_") && value instanceof Boolean);
+        return additionalMetrics((key, value) -> key.startsWith("bool_"));
     }
 
     private <T> Map<String, T> additionalMetrics(BiPredicate<String, Object> typeGard) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9761

**Description**

When metrics object is serialized (with Jackson for example), long additional metric may be deserialized as Integer and therefore can't be get anymore.

As we ensure the type when adding the metric, we should be safe removing this check when getting an additional metric.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.33.1-apim9761-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.33.1-apim9761-SNAPSHOT/gravitee-reporter-api-1.33.1-apim9761-SNAPSHOT.zip)
  <!-- Version placeholder end -->
