### PR TITLE
feat: adapt elastic reporter to handle native kafka metrics

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/eventnative/EventNativeMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/eventnative/EventNativeMetrics.java
@@ -30,12 +30,12 @@ public class EventNativeMetrics extends AbstractReportable {
     /**
      * Base dimensions
      */
-    private String planId;
-    private String apiId;
-    private String applicationId;
     private String gatewayId;
-    private String environmentId;
     private String organizationId;
+    private String environmentId;
+    private String apiId;
+    private String planId;
+    private String applicationId;
     private String topic;
     /**
      * Metrics
@@ -54,32 +54,30 @@ public class EventNativeMetrics extends AbstractReportable {
     public EventNativeMetrics() {}
 
     public EventNativeMetrics(
-        @NonNull Long timestamp,
-        @NonNull String planId,
-        @NonNull String apiId,
-        @NonNull String applicationId,
         @NonNull String gatewayId,
-        @NonNull String environmentId,
         @NonNull String organizationId,
+        @NonNull String environmentId,
+        @NonNull String apiId,
+        @NonNull String planId,
+        @NonNull String applicationId,
         @Nullable String topic
     ) {
-        super(timestamp);
         log.trace(
-            "Creating event native metrics at timestamp:{} for plan:{} api:{} application:{} gateway:{} environment:{} organization:{}",
-            timestamp,
-            planId,
-            apiId,
-            applicationId,
+            "Creating event native metrics for gateway:{} organization:{} environment:{} api:{} plan:{} application:{} topic:{}",
             gatewayId,
+            organizationId,
             environmentId,
-            organizationId
+            apiId,
+            planId,
+            applicationId,
+            topic
         );
-        this.planId = planId;
-        this.apiId = apiId;
-        this.applicationId = applicationId;
         this.gatewayId = gatewayId;
-        this.environmentId = environmentId;
         this.organizationId = organizationId;
+        this.environmentId = environmentId;
+        this.apiId = apiId;
+        this.planId = planId;
+        this.applicationId = applicationId;
         this.topic = topic;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Added ES document model for event native metrics.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-kafka-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-kafka-metrics-SNAPSHOT/gravitee-reporter-api-1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-kafka-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
