### PR TITLE
feat: renamed class EventNativeMetrics to EventMetrics

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/EventMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/EventMetrics.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.reporter.api.v4.metric.eventnative;
+package io.gravitee.reporter.api.v4.metric;
 
 import io.gravitee.reporter.api.AbstractReportable;
 import javax.annotation.Nullable;
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Setter
 @ToString(callSuper = true)
-public class EventNativeMetrics extends AbstractReportable {
+public class EventMetrics extends AbstractReportable {
 
     /**
      * Base dimensions
@@ -60,12 +60,12 @@ public class EventNativeMetrics extends AbstractReportable {
     private Number downstreamAuthorizationSuccessesTotal;
     private Number upstreamAuthorizationSuccessesTotal;
 
-    public EventNativeMetrics() {}
+    public EventMetrics() {}
 
     /**
      * Constructor with all identifiers.
      */
-    public EventNativeMetrics(
+    public EventMetrics(
         @NonNull String gatewayId,
         @NonNull String organizationId,
         @NonNull String environmentId,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Renamed class `EventNativeMetrics` to `EventMetrics`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-api-1.35.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
