### PR TITLE
feat: add apiProductId to v4 Metrics and Log

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -34,6 +34,7 @@ public class Log extends AbstractReportable {
 
     private String apiId;
     private String apiName;
+    private String apiProductId;
 
     /**
      * Log identifier is equivalent to the request identifier

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -45,6 +45,7 @@ public class Metrics extends AbstractReportable implements WithAdditional<Metric
     private String transactionId;
     private String apiId;
     private String apiName;
+    private String apiProductId;
     private String apiType;
     private String planId;
     private String applicationId;

--- a/src/test/java/io/gravitee/reporter/api/v4/metric/MetricsToV2MappingTest.java
+++ b/src/test/java/io/gravitee/reporter/api/v4/metric/MetricsToV2MappingTest.java
@@ -43,6 +43,7 @@ class MetricsToV2MappingTest {
             .planId("plan-x")
             .applicationId("app-id")
             .subscriptionId("sub-1")
+            .apiProductId("product-1")
             .clientIdentifier("client-xyz")
             .organizationId("org-7")
             .environmentId("env-6")
@@ -109,6 +110,7 @@ class MetricsToV2MappingTest {
         assertThat(v2.getPlan()).isEqualTo("plan-x");
         assertThat(v2.getSubscription()).isEqualTo("sub-1");
         assertThat(v2.getClientIdentifier()).isEqualTo("client-xyz");
+        // apiProductId is v4-only — not forwarded to v2 (v2 APIs do not support API Products)
         assertThat(v2.getOrganizationId()).isEqualTo("org-7");
         assertThat(v2.getEnvironmentId()).isEqualTo("env-6");
 


### PR DESCRIPTION
## Issue

[APIM-13543](https://gravitee.atlassian.net/browse/APIM-13543)

## Why

All downstream tasks in APIM-13506 (gateway-side analytics and Elasticsearch reporter changes) need `apiProductId` to exist on the v4 DTOs before they can populate or read the field. Without this, the SubscriptionProcessor and Elasticsearch FTL templates have no field to write to.

Adding `apiProductId` to `v4.log.Log` is required by **REQ-1.3 (P0)** in the API Products Phase 2 PRD: *"Every request log entry for a product subscription must include `api_product_id` and `api_product_plan_id` metadata."* The `v4.log.Log` class has no `additionalMetrics` fallback, so a library-level field is the only path for the access log requirement.

## What changed

- Added `private String apiProductId` (nullable `String`) to `v4.metric.Metrics`, in the identifiers block after `subscriptionId`
- Added `private String apiProductId` (nullable `String`) to `v4.log.Log`, after `apiName`

No existing behaviour changed. The field defaults to `null` via Lombok `@SuperBuilder` with no additional wiring required.

## User-facing impact

`apiProductId` is intentionally not forwarded in `Metrics.toV2()` — v2 HTTP APIs do not support API Products, so the field is a v4-only concern.

## How to test

```bash
mvn clean package
```

No behaviour change — confirm existing tests pass. The new field is accessible via the generated `getApiProductId()` / `setApiProductId()` accessors on both DTOs.



[APIM-13543]: https://gravitee.atlassian.net/browse/APIM-13543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-apim-13543-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.2.0-apim-13543-SNAPSHOT/gravitee-reporter-api-2.2.0-apim-13543-SNAPSHOT.zip)
  <!-- Version placeholder end -->
