### PR TITLE
feat: root-cause message resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Diagnostic.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Diagnostic.java
@@ -19,6 +19,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 @Data
 @AllArgsConstructor
@@ -30,4 +32,36 @@ public class Diagnostic {
     private String message;
     private String componentType;
     private String componentName;
+
+    /**
+     * Builds a diagnostic from a throwable. The {@code key} is the root cause's fully qualified
+     * class name; the {@code message} is resolved via {@link #resolveErrorMessage(Throwable)}.
+     * Returns {@code null} when {@code error} is {@code null} — callers can skip reporting.
+     */
+    public static Diagnostic fromError(Throwable error, String componentType, String componentName) {
+        if (error == null) {
+            return null;
+        }
+        Throwable root = ExceptionUtils.getRootCause(error);
+        return new Diagnostic(root.getClass().getName(), resolveErrorMessage(error), componentType, componentName);
+    }
+
+    /**
+     * Resolves a non-null throwable to its most informative message. Priority: non-blank message
+     * of the root cause (last distinct node, cycle-safe via identity tracking in
+     * {@link ExceptionUtils}) → first non-blank message walking outer-to-inner → root's fully
+     * qualified class name.
+     */
+    private static String resolveErrorMessage(Throwable error) {
+        Throwable root = ExceptionUtils.getRootCause(error);
+        if (StringUtils.isNotBlank(root.getMessage())) {
+            return root.getMessage();
+        }
+        for (Throwable t : ExceptionUtils.getThrowableList(error)) {
+            if (StringUtils.isNotBlank(t.getMessage())) {
+                return t.getMessage();
+            }
+        }
+        return root.getClass().getName();
+    }
 }

--- a/src/test/java/io/gravitee/reporter/api/v4/metric/DiagnosticTest.java
+++ b/src/test/java/io/gravitee/reporter/api/v4/metric/DiagnosticTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api.v4.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DiagnosticTest {
+
+    @Test
+    void should_build_diagnostic_from_error_with_root_cause_message_and_class_name_as_key() {
+        Throwable error = new RuntimeException("wrapper", new IllegalStateException("root cause"));
+
+        Diagnostic diagnostic = Diagnostic.fromError(error, "kafka-reactor", "kafka-reactor");
+
+        assertThat(diagnostic.getKey()).isEqualTo(IllegalStateException.class.getName());
+        assertThat(diagnostic.getMessage()).isEqualTo("root cause");
+        assertThat(diagnostic.getComponentType()).isEqualTo("kafka-reactor");
+        assertThat(diagnostic.getComponentName()).isEqualTo("kafka-reactor");
+    }
+
+    @Test
+    void should_fall_back_to_class_name_when_no_message_in_chain() {
+        Diagnostic diagnostic = Diagnostic.fromError(new NullPointerException(), "k", "k");
+
+        assertThat(diagnostic.getKey()).isEqualTo(NullPointerException.class.getName());
+        assertThat(diagnostic.getMessage()).isEqualTo(NullPointerException.class.getName());
+    }
+
+    @Test
+    void should_return_null_when_error_is_null() {
+        assertThat(Diagnostic.fromError(null, "k", "k")).isNull();
+    }
+
+    @Test
+    void should_return_class_name_on_cycle_with_null_messages() {
+        Throwable a = new RuntimeException();
+        Throwable b = new RuntimeException();
+        a.initCause(b);
+        b.initCause(a);
+
+        assertThat(Diagnostic.fromError(a, "k", "k").getMessage()).isEqualTo(RuntimeException.class.getName());
+    }
+
+    @Test
+    void should_skip_blank_messages_and_return_next_non_blank_in_chain() {
+        Throwable error = new RuntimeException("wrapper", new IllegalStateException("   ", new NullPointerException("")));
+
+        assertThat(Diagnostic.fromError(error, "k", "k").getMessage()).isEqualTo("wrapper");
+    }
+
+    @Test
+    void should_return_middle_message_when_only_middle_exception_has_one() {
+        Throwable root = new NullPointerException();
+        Throwable middle = new IllegalStateException("middle cause", root);
+        Throwable outer = new RuntimeException((String) null, middle);
+
+        assertThat(Diagnostic.fromError(outer, "k", "k").getMessage()).isEqualTo("middle cause");
+    }
+}


### PR DESCRIPTION
## Issue

[APIM-13587](https://gravitee.atlassian.net/browse/APIM-13587)

## Why

During review of the Kafka reactor's connection-metrics reporter, a small exception-to-`Diagnostic` helper was written locally to unwrap root causes and resolve the most informative error message. The same logic applies to any reporter caller that builds a `Diagnostic` from a `Throwable` (HTTP reactor, future reporters). Moving it here avoids the duplication opportunity at the source.

## What changed

- `Diagnostic.fromError(key, throwable, componentType, componentName)` — static factory that builds a `Diagnostic` with the message resolved from the throwable.
- `Diagnostic.resolveErrorMessage(throwable)` — exposed for callers that also need the string independently (e.g. to populate `Metrics.errorMessage`).
- Resolution priority: root-cause message → first non-null message walking outer → inner → root exception class name. Returns `"unknown"` for a `null` error.
- Private `rootCauseOf` helper with a cycle guard (defensive against subclasses that override `getCause()`).

No behaviour change to the existing `Diagnostic` constructors, fields, or Lombok-generated accessors.

## How to test

```bash
mvn test
```

New `DiagnosticTest` covers the four message-resolution branches plus the null-error path. All 33 pre-existing tests unaffected.

## Consumer

`gravitee-reactor-native-kafka` branch `apim-13587` will be updated to consume `Diagnostic.fromError` once this is released.

[APIM-13587]: https://gravitee.atlassian.net/browse/APIM-13587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.0-apim-13587-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.3.0-apim-13587-SNAPSHOT/gravitee-reporter-api-2.3.0-apim-13587-SNAPSHOT.zip)
  <!-- Version placeholder end -->
