### PR TITLE
feat(APIM-13616): add traceId and spanId fields to log model classes

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/common/Request.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Request.java
@@ -40,6 +40,10 @@ public class Request {
 
     private String body;
 
+    private String traceId;
+
+    private String spanId;
+
     public Request doOnReport(ReportAction<Request> action) {
         if (onReportActions == null) {
             onReportActions = new ArrayList<>();

--- a/src/main/java/io/gravitee/reporter/api/common/Response.java
+++ b/src/main/java/io/gravitee/reporter/api/common/Response.java
@@ -39,6 +39,10 @@ public class Response {
 
     private String body;
 
+    private String traceId;
+
+    private String spanId;
+
     public Response(final int status) {
         this.status = status;
     }

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -46,4 +46,6 @@ public class MessageLog extends AbstractReportable {
     private MessageConnectorType connectorType;
     private String connectorId;
     private Message message;
+    private String traceId;
+    private String spanId;
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13616

**Description**

Adds traceId and spanId fields to Request, Response, and MessageLog to support OTel trace-log correlation. 
These fields are populated by the gateway when OpenTelemetry tracing is active and carried through to reporters

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->