### PR TITLE
feat(log): add organizationId and environmentId to v4 Log and MessageLog

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -41,6 +41,8 @@ public class Log extends AbstractReportable {
      */
     private String requestId;
     private String clientIdentifier;
+    private String organizationId;
+    private String environmentId;
     private boolean requestEnded;
     private Request entrypointRequest;
     private Request endpointRequest;

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -40,6 +40,8 @@ public class MessageLog extends AbstractReportable {
     private String apiName;
     private String requestId;
     private String clientIdentifier;
+    private String organizationId;
+    private String environmentId;
     private String correlationId;
     private String parentCorrelationId;
     private MessageOperation operation;


### PR DESCRIPTION
## Summary
- Add `organizationId` + `environmentId` to `v4/log/Log` and `v4/log/MessageLog`, mirroring the same fields already on `v4/metric/Metrics`.
- Purely additive — no behaviour change, no breaking API change.

## Why
Downstream reporters that need to scope log records by tenant (in particular the OTel reporter, where `gravitee.env.id` becomes a per-record OTLP attribute) currently can't, because the reportable doesn't carry the env. The gateway already populates org/env on `Metrics` (see `DefaultApiReactor` / `SyncApiReactor` `setOrganizationId` / `setEnvironmentId`) — this PR makes `Log` / `MessageLog` carry the same scope so the gateway can populate them at the same construction sites.

Without this, the gamma trace explorer drops payload logs at read time because its env filter targets a resource attribute that the OTel reporter has no way to stamp per-call.

## Follow-ups (separate PRs)
1. `gravitee-api-management` — populate org/env in `LogInitProcessor` + `MetricsAdapter` Log builder once a release of this lib is available.
2. `gravitee-reactor-message` — same for `MessageLog` in `MessageReporter`.
3. `gravitee-reporter-otel` — drop static-config org, lazy-init Logger from first record's org, stamp `gravitee.env.id` as a per-record attribute.
4. `gravitee-api-management` (gamma read path) — switch the envId filter from `resource.attributes.gravitee.env.id` to `attributes.gravitee.env.id`.

## Test plan
- [ ] CI passes
- [ ] Verify Jackson serialization round-trip (handled by `@Jacksonized` `@SuperBuilder` — covered by the existing builder/lombok machinery)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.4.0-feat-log-org-env-attrs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.4.0-feat-log-org-env-attrs-SNAPSHOT/gravitee-reporter-api-2.4.0-feat-log-org-env-attrs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
