### PR TITLE
feat: add ReportTarget routing for reporter dispatch

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
+++ b/src/main/java/io/gravitee/reporter/api/AbstractReportable.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 

--- a/src/main/java/io/gravitee/reporter/api/ReportTarget.java
+++ b/src/main/java/io/gravitee/reporter/api/ReportTarget.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Identifies the intended destination of a {@link Reportable}.
+ *
+ * <p>A reportable may target one or more destinations (e.g. analytics backends
+ * like Elasticsearch, or tracing backends like an OTLP collector). Reporters
+ * declare which targets they support via {@link Reporter#supportedTargets()},
+ * and the dispatch layer only forwards a reportable to reporters whose
+ * supported targets intersect with the reportable's targets.
+ *
+ * @author Ayoub RAFFASS (ayoub.raffass at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum ReportTarget {
+    /** Analytics reporters: Elasticsearch, file, TCP, Datadog, etc. */
+    ANALYTICS,
+
+    /** Tracing reporters: OpenTelemetry log exporter (Loki, OTLP). */
+    TRACING;
+
+    /** Shared immutable set containing all targets. */
+    public static final Set<ReportTarget> ALL = Collections.unmodifiableSet(EnumSet.allOf(ReportTarget.class));
+
+    /** Default target for reportables and reporters — matches the pre-OTel historical behavior. */
+    public static final Set<ReportTarget> DEFAULT = Collections.unmodifiableSet(EnumSet.of(ANALYTICS));
+}

--- a/src/main/java/io/gravitee/reporter/api/Reportable.java
+++ b/src/main/java/io/gravitee/reporter/api/Reportable.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.reporter.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -23,4 +25,18 @@ import java.time.Instant;
  */
 public interface Reportable {
     Instant timestamp();
+
+    /**
+     * Returns the set of {@link ReportTarget}s this reportable is intended for.
+     * The dispatch layer uses this to route the reportable only to reporters
+     * whose {@link Reporter#supportedTargets()} intersect with this set.
+     *
+     * <p>Defaults to {@link ReportTarget#DEFAULT} ({@code ANALYTICS}) — the historical
+     * behavior before the OTel reporter was introduced. Only reportables that explicitly
+     * opt in to {@code TRACING} are dispatched to tracing reporters.
+     */
+    @JsonIgnore
+    default Set<ReportTarget> getTargets() {
+        return ReportTarget.DEFAULT;
+    }
 }

--- a/src/main/java/io/gravitee/reporter/api/Reporter.java
+++ b/src/main/java/io/gravitee/reporter/api/Reporter.java
@@ -16,8 +16,7 @@
 package io.gravitee.reporter.api;
 
 import io.gravitee.common.service.Service;
-import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -28,5 +27,19 @@ public interface Reporter extends Service<Reporter> {
 
     default boolean canHandle(Reportable reportable) {
         return true;
+    }
+
+    /**
+     * Returns the set of {@link ReportTarget}s this reporter is able to handle.
+     * The dispatch layer only forwards a {@link Reportable} to this reporter when
+     * at least one of the reportable's targets matches one of the reporter's
+     * supported targets.
+     *
+     * <p>Defaults to {@link ReportTarget#DEFAULT} ({@code ANALYTICS}) — the historical
+     * behavior before the OTel reporter was introduced. Only reporters that explicitly
+     * opt in to {@code TRACING} receive tracing-targeted reportables.
+     */
+    default Set<ReportTarget> supportedTargets() {
+        return ReportTarget.DEFAULT;
     }
 }

--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.reporter.api.v4.log;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.reporter.api.AbstractReportable;
+import io.gravitee.reporter.api.ReportTarget;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
+import java.util.Set;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
@@ -31,6 +34,15 @@ import lombok.extern.jackson.Jacksonized;
 @SuperBuilder
 @Jacksonized
 public class Log extends AbstractReportable {
+
+    @JsonIgnore
+    @Builder.Default
+    private Set<ReportTarget> targets = ReportTarget.DEFAULT;
+
+    @Override
+    public Set<ReportTarget> getTargets() {
+        return targets != null ? targets : ReportTarget.DEFAULT;
+    }
 
     private String apiId;
     private String apiName;

--- a/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/MessageLog.java
@@ -15,10 +15,14 @@
  */
 package io.gravitee.reporter.api.v4.log;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.reporter.api.AbstractReportable;
+import io.gravitee.reporter.api.ReportTarget;
 import io.gravitee.reporter.api.v4.common.Message;
 import io.gravitee.reporter.api.v4.common.MessageConnectorType;
 import io.gravitee.reporter.api.v4.common.MessageOperation;
+import java.util.Set;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -35,6 +39,15 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 @ToString(callSuper = true)
 public class MessageLog extends AbstractReportable {
+
+    @JsonIgnore
+    @Builder.Default
+    private Set<ReportTarget> targets = ReportTarget.DEFAULT;
+
+    @Override
+    public Set<ReportTarget> getTargets() {
+        return targets != null ? targets : ReportTarget.DEFAULT;
+    }
 
     private String apiId;
     private String apiName;

--- a/src/test/java/io/gravitee/reporter/api/ReportTargetTest.java
+++ b/src/test/java/io/gravitee/reporter/api/ReportTargetTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.reporter.api.v4.log.Log;
+import io.gravitee.reporter.api.v4.log.MessageLog;
+import java.util.EnumSet;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReportTargetTest {
+
+    @Test
+    void all_should_contain_both_targets() {
+        assertThat(ReportTarget.ALL).containsExactlyInAnyOrder(ReportTarget.ANALYTICS, ReportTarget.TRACING);
+    }
+
+    @Test
+    void all_should_be_unmodifiable() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> ReportTarget.ALL.add(ReportTarget.ANALYTICS)
+        );
+    }
+
+    @Test
+    void default_should_contain_analytics_only() {
+        assertThat(ReportTarget.DEFAULT).containsExactly(ReportTarget.ANALYTICS);
+    }
+
+    @Test
+    void default_should_be_unmodifiable() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> ReportTarget.DEFAULT.add(ReportTarget.TRACING)
+        );
+    }
+
+    @Nested
+    class LogTargets {
+
+        @Test
+        void should_default_to_all_targets() {
+            var log = Log.builder().build();
+            assertThat(log.getTargets()).isEqualTo(ReportTarget.DEFAULT);
+        }
+
+        @Test
+        void should_accept_specific_targets_via_builder() {
+            var log = Log.builder().targets(EnumSet.of(ReportTarget.TRACING)).build();
+            assertThat(log.getTargets()).containsExactly(ReportTarget.TRACING);
+        }
+
+        @Test
+        void should_accept_specific_targets_via_setter() {
+            var log = Log.builder().build();
+            log.setTargets(EnumSet.of(ReportTarget.ANALYTICS));
+            assertThat(log.getTargets()).containsExactly(ReportTarget.ANALYTICS);
+        }
+
+        @Test
+        void should_return_all_when_targets_set_to_null() {
+            var log = Log.builder().build();
+            log.setTargets(null);
+            assertThat(log.getTargets()).isEqualTo(ReportTarget.DEFAULT);
+        }
+    }
+
+    @Nested
+    class MessageLogTargets {
+
+        @Test
+        void should_default_to_all_targets() {
+            var messageLog = MessageLog.builder().build();
+            assertThat(messageLog.getTargets()).isEqualTo(ReportTarget.DEFAULT);
+        }
+
+        @Test
+        void should_accept_specific_targets_via_builder() {
+            var messageLog = MessageLog.builder().targets(EnumSet.of(ReportTarget.TRACING)).build();
+            assertThat(messageLog.getTargets()).containsExactly(ReportTarget.TRACING);
+        }
+    }
+
+    @Nested
+    class ReportableInterfaceDefault {
+
+        @Test
+        void should_default_to_all_targets_for_anonymous_reportable() {
+            Reportable reportable = java.time.Instant::now;
+            assertThat(reportable.getTargets()).isEqualTo(ReportTarget.DEFAULT);
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14388

**Description**

- New `ReportTarget` enum (`ANALYTICS`, `TRACING`) with shared `ALL` constant
- `Reportable.getTargets()` default method - intended destinations for a log
- `Reporter.supportedTargets()` default method - what a reporter handles
- `targets` field on `Log` and `MessageLog` with `@JsonIgnore` + `@Builder.Default`
- added tests as well

**Additional context**

When OTel Logs is enabled but ES logging is off, the gateway still sends Log objects to all reporters including Elasticsearch causing double writes and GC pressure. 

This PR adds the routing API that downstream repos use to filter dispatch.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.0-fix-APIM-14388-report-target-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.5.0-fix-APIM-14388-report-target-SNAPSHOT/gravitee-reporter-api-2.5.0-fix-APIM-14388-report-target-SNAPSHOT.zip)
  <!-- Version placeholder end -->
