### PR TITLE
feat: add applicationName to Metrics and error/subscription fields to Log

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/log/Log.java
@@ -55,6 +55,12 @@ public class Log extends AbstractReportable {
     private String clientIdentifier;
     private String organizationId;
     private String environmentId;
+    private String applicationId;
+    private String applicationName;
+    private String planId;
+    private String subscriptionId;
+    private String errorKey;
+    private String errorMessage;
     private boolean requestEnded;
     private Request entrypointRequest;
     private Request endpointRequest;

--- a/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/Metrics.java
@@ -49,6 +49,7 @@ public class Metrics extends AbstractReportable implements WithAdditional<Metric
     private String apiType;
     private String planId;
     private String applicationId;
+    private String applicationName;
     private String subscriptionId;
     private String clientIdentifier;
     private String organizationId;


### PR DESCRIPTION
## Summary

  - Add **applicationName** field to V4 Metrics model
  - Add **applicationId**, **applicationName**, **planId**, **subscriptionId**, **errorKey**, **errorMessage** fields to V4 Log model

##  Context

  These fields are needed to enrich DataDog reporter metrics tags and log payloads with application identity and error context, enabling customers to troubleshoot API failures directly from DataDog without cross-referencing other tools.

##  Related

  - https://gravitee.atlassian.net/browse/APIM-14595
  - https://gravitee.atlassian.net/browse/APIM-14012
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.0-feat-APIM-14012-add-application-and-error-fields-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.6.0-feat-APIM-14012-add-application-and-error-fields-SNAPSHOT/gravitee-reporter-api-2.6.0-feat-APIM-14012-add-application-and-error-fields-SNAPSHOT.zip)
  <!-- Version placeholder end -->
