### PR TITLE
refactor(metrics): rename CALLER_REACTOR to CALLER_GATEWAY

### DIFF
--- a/src/main/java/io/gravitee/reporter/api/v4/metric/event/AuthzEventMetrics.java
+++ b/src/main/java/io/gravitee/reporter/api/v4/metric/event/AuthzEventMetrics.java
@@ -49,7 +49,7 @@ public class AuthzEventMetrics extends BaseEventMetrics {
     public static final String EFFECT_FORBID = "FORBID";
 
     public static final String CALLER_PEP = "pep";
-    public static final String CALLER_REACTOR = "reactor";
+    public static final String CALLER_GATEWAY = "gateway";
     public static final String CALLER_AUTHZEN = "authzen";
     public static final String CALLER_UNKNOWN = "unknown";
 


### PR DESCRIPTION
Renames the caller constant introduced in #139 before anything consumes it.

`reactor` names an implementation detail — how the gateway hosts an authz API — where the other two values (`pep`, `authzen`) name the component that asked for the decision. `gateway` is the consistent answer to "who called the PDP".

Value and constant both change: `CALLER_REACTOR = "reactor"` becomes `CALLER_GATEWAY = "gateway"`. 2.7.0 shipped the old name, but no released component reads it yet — the producers and the PDP that use these constants are all still open PRs.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.7.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-api/2.7.0/gravitee-reporter-api-2.7.0.zip)
  <!-- Version placeholder end -->
